### PR TITLE
optimized the native share button for tablets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
  All notable changes to this project will be documented in this file.
  The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [2.2.0] - 2022-02-18
+### Changed
+- optimized the native share button for tablets
+
 ### [2.1.4] - 2020-06-18
 ### Fixed
 - aria label

--- a/extension-config.json
+++ b/extension-config.json
@@ -19,6 +19,47 @@
       "path": "frontend/portals/NavbarNavigatorCartButtonBefore",
       "target": "app-bar.cart-button.before",
       "type": "portals"
+    },
+    {
+      "id": "ProductTabletRightColumnCTAS",
+      "path": "frontend/portals/ProductTabletRightColumnCTAS",
+      "target": "product.tablet.right-column.ctas",
+      "type": "portals"
+    },
+    {
+      "id": "en-US",
+      "path": "frontend/locale/en-US.json",
+      "type": "translations"
+    },
+    {
+      "id": "es-ES",
+      "path": "frontend/locale/es-ES.json",
+      "type": "translations"
+    },
+    {
+      "id": "de-DE",
+      "path": "frontend/locale/de-DE.json",
+      "type": "translations"
+    },
+    {
+      "id": "fr-FR",
+      "path": "frontend/locale/fr-FR.json",
+      "type": "translations"
+    },
+    {
+      "id": "it-IT",
+      "path": "frontend/locale/it-IT.json",
+      "type": "translations"
+    },
+    {
+      "id": "nl-NL",
+      "path": "frontend/locale/nl-NL.json",
+      "type": "translations"
+    },
+    {
+      "id": "pt-PT",
+      "path": "frontend/locale/pt-PT.json",
+      "type": "translations"
     }
   ],
   "steps": [],

--- a/frontend/components/ShareButton/index.jsx
+++ b/frontend/components/ShareButton/index.jsx
@@ -72,7 +72,7 @@ class ShareButton extends Component {
 
     return (
       <button
-        className={`${this.constructor.getIconStyle()} ${this.props.className}`}
+        className={`${this.constructor.getIconStyle()} ${this.props.className} share-button-mobile-mode`}
         data-test-id="shareIcon"
         type="button"
         aria-label={i18n.text('product.share')}

--- a/frontend/components/ShareButtonForTabletExtension/index.jsx
+++ b/frontend/components/ShareButtonForTabletExtension/index.jsx
@@ -101,7 +101,7 @@ class ShareButtonForTabletExtension extends Component {
         type="button"
       >
         <span>{this.renderIcon()}</span>
-        <I18n.Text string="shareButton.label" />
+        <I18n.Text string="pdpNativeShare.shareButton.label" />
       </button>
     );
   }

--- a/frontend/components/ShareButtonForTabletExtension/index.jsx
+++ b/frontend/components/ShareButtonForTabletExtension/index.jsx
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import I18n from '@shopgate/pwa-common/components/I18n';
+import ShareIconiOS from '@shopgate/pwa-ui-ios/icons/ShareIcon';
+import ShareIconGmd from '@shopgate/pwa-ui-material/icons/ShareIcon';
+import isIOSTheme from '@shopgate-ps/pwa-extension-kit/env/helpers/isIOSTheme';
+import { withPageProductId } from '@shopgate-ps/pwa-extension-kit/connectors';
+import { css } from 'glamor';
+import connect from '../../connector';
+import styles from './style';
+
+/**
+ * The share button component for the tablet adjustments extension.
+ */
+class ShareButtonForTabletExtension extends Component {
+  static propTypes = {
+    shareItem: PropTypes.func.isRequired,
+    'aria-hidden': PropTypes.bool,
+    shareParams: PropTypes.shape(),
+  };
+
+  /**
+   * Context types definition.
+   * @type {{i18n: shim}}
+   */
+  static contextTypes = {
+    i18n: PropTypes.func,
+  };
+
+  static defaultProps = {
+    'aria-hidden': null,
+    shareParams: null,
+  };
+
+  /**
+   * Construct and init state
+   * @param {Object} props Component props
+   */
+  constructor(props) {
+    super(props);
+    this.clickedOnce = false;
+  }
+
+  /**
+   * Hide StickyShareButton if tablet-adjustment-extension is enabled and tablet mode is active
+   */
+  componentDidMount() {
+    css.global('.share-button-mobile-mode', { display: 'none' });
+  }
+
+  /**
+   * Show StickyShareButton if mobile mode is active
+   */
+  componentWillUnmount() {
+    css.global('.share-button-mobile-mode', { display: 'block' });
+  }
+
+  /**
+   * Returns text for aria-label.
+   * @returns {string}
+   */
+  getLabel() {
+    const { __ } = this.context.i18n();
+    const lang = 'shareButton.label';
+    return __(lang);
+  }
+
+  /**
+   * Handles the share button click
+   * Show's share screen for app
+   * @param {Object} event The click event object
+   */
+  handleClick = () => {
+    this.props.shareItem();
+  };
+
+  /**
+   * Renders the share icon depending on theme
+   * @returns {JSX}
+   */
+  renderIcon = () => (
+    isIOSTheme ? <ShareIconiOS className={styles.icon} /> : <ShareIconGmd className={styles.icon} />
+  );
+
+  /**
+   * Renders the component.
+   * @returns {JSX|null}
+   */
+  render() {
+    if (!this.props.shareParams || this.props.shareParams.deepLink === undefined) {
+      return null;
+    }
+
+    return (
+      <button
+        aria-label={this.getLabel()}
+        aria-hidden={this.props['aria-hidden']}
+        className={`ui-shared__share-button-for-tablet-extension ${styles.button}`}
+        onClick={this.handleClick}
+        data-test-id="shareButtonForTabletExtension"
+        type="button"
+      >
+        <span>{this.renderIcon()}</span>
+        <I18n.Text string="shareButton.label" />
+      </button>
+    );
+  }
+}
+
+export default withPageProductId(connect(ShareButtonForTabletExtension));

--- a/frontend/components/ShareButtonForTabletExtension/style.js
+++ b/frontend/components/ShareButtonForTabletExtension/style.js
@@ -1,0 +1,36 @@
+import { css } from 'glamor';
+import { themeConfig } from '@shopgate/pwa-common/helpers/config';
+
+const { colors, variables } = themeConfig;
+
+const button = css({
+  marginTop: 10,
+  display: 'block',
+  flexGrow: 1,
+  border: `1px solid ${colors.accent}`,
+  color: colors.accent,
+  fontSize: 16,
+  fontWeight: 700,
+  borderRadius: 5,
+  width: '100%',
+  outline: 0,
+  transition: 'width 300ms cubic-bezier(0.25, 0.1, 0.25, 1)',
+  padding: `${(variables.gap.big * 0.75) - 1}px ${variables.gap.big * 0.6}px ${(variables.gap.big * 0.75) + 1}px`,
+  marginLeft: 8,
+});
+
+const disabled = css(button, {
+  background: colors.shade5,
+});
+
+const icon = css({
+  display: 'inline',
+  marginBottom: -2,
+  marginRight: 5,
+});
+
+export default {
+  button,
+  disabled,
+  icon,
+};

--- a/frontend/locale/de-DE.json
+++ b/frontend/locale/de-DE.json
@@ -1,5 +1,7 @@
 {
-  "shareButton": {
-    "label": "Artikel teilen"
+  "pdpNativeShare": {
+    "shareButton": {
+      "label": "Artikel teilen"
+    }
   }
 }

--- a/frontend/locale/de-DE.json
+++ b/frontend/locale/de-DE.json
@@ -1,0 +1,5 @@
+{
+  "shareButton": {
+    "label": "Artikel teilen"
+  }
+}

--- a/frontend/locale/en-US.json
+++ b/frontend/locale/en-US.json
@@ -1,0 +1,5 @@
+{
+  "shareButton": {
+    "label": "Share product"
+  }
+}

--- a/frontend/locale/en-US.json
+++ b/frontend/locale/en-US.json
@@ -1,5 +1,7 @@
 {
-  "shareButton": {
-    "label": "Share product"
+  "pdpNativeShare": {
+    "shareButton": {
+      "label": "Share product"
+    }
   }
 }

--- a/frontend/locale/es-ES.json
+++ b/frontend/locale/es-ES.json
@@ -1,0 +1,5 @@
+{
+  "shareButton": {
+    "label": "Compartir el producto"
+  }
+}

--- a/frontend/locale/es-ES.json
+++ b/frontend/locale/es-ES.json
@@ -1,5 +1,7 @@
 {
-  "shareButton": {
-    "label": "Compartir el producto"
+  "pdpNativeShare": {
+    "shareButton": {
+      "label": "Compartir el producto"
+    }
   }
 }

--- a/frontend/locale/fr-FR.json
+++ b/frontend/locale/fr-FR.json
@@ -1,0 +1,5 @@
+{
+  "shareButton": {
+    "label": "Partager le produit"
+  }
+}

--- a/frontend/locale/fr-FR.json
+++ b/frontend/locale/fr-FR.json
@@ -1,5 +1,7 @@
 {
-  "shareButton": {
-    "label": "Partager le produit"
+  "pdpNativeShare": {
+    "shareButton": {
+      "label": "Partager le produit"
+    }
   }
 }

--- a/frontend/locale/it-IT.json
+++ b/frontend/locale/it-IT.json
@@ -1,0 +1,5 @@
+{
+  "shareButton": {
+    "label": "Condividi il prodotto"
+  }
+}

--- a/frontend/locale/it-IT.json
+++ b/frontend/locale/it-IT.json
@@ -1,5 +1,7 @@
 {
-  "shareButton": {
-    "label": "Condividi il prodotto"
+  "pdpNativeShare": {
+    "shareButton": {
+      "label": "Condividi il prodotto"
+    }
   }
 }

--- a/frontend/locale/nl-NL.json
+++ b/frontend/locale/nl-NL.json
@@ -1,5 +1,7 @@
 {
-  "shareButton": {
-    "label": "Product delen"
+  "pdpNativeShare": {
+    "shareButton": {
+      "label": "Product delen"
+    }
   }
 }

--- a/frontend/locale/nl-NL.json
+++ b/frontend/locale/nl-NL.json
@@ -1,0 +1,5 @@
+{
+  "shareButton": {
+    "label": "Product delen"
+  }
+}

--- a/frontend/locale/pt-PT.json
+++ b/frontend/locale/pt-PT.json
@@ -1,5 +1,7 @@
 {
-  "shareButton": {
-    "label": "Partilhar produto"
+  "pdpNativeShare": {
+    "shareButton": {
+      "label": "Partilhar produto"
+    }
   }
 }

--- a/frontend/locale/pt-PT.json
+++ b/frontend/locale/pt-PT.json
@@ -1,0 +1,5 @@
+{
+  "shareButton": {
+    "label": "Partilhar produto"
+  }
+}

--- a/frontend/portals/ProductTabletRightColumnCTAS/index.jsx
+++ b/frontend/portals/ProductTabletRightColumnCTAS/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ShareButtonForTabletExtension from '../../components/ShareButtonForTabletExtension';
+
+export default props => (
+  <ShareButtonForTabletExtension {...props} />
+);


### PR DESCRIPTION
# Pull Request Template

## Description

Added the functionality, that the share button is shown next to the "add to favorites" button, if the tablet-adjustment-extension is enabled.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
