### PR TITLE
Fixed a11y label for tablet share button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
  The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## 2.3.1 - 2026-05-04
+### Fixed
+- a11y label for tablet share button
+
 ## 2.3.0 - 2025-07-02
 ### Added
 - added css classes

--- a/frontend/components/ShareButton/index.jsx
+++ b/frontend/components/ShareButton/index.jsx
@@ -74,7 +74,7 @@ class ShareButton extends Component {
         className={`${this.constructor.getIconStyle()} ${this.props.className} share-button-mobile-mode`}
         data-test-id="shareIcon"
         type="button"
-        aria-label={i18n.text('product.share')}
+        aria-label={i18n.text('pdpNativeShare.shareButton.label')}
       >
         <Ripple className={`${styles.ripple(isIOSTheme())} ${this.props.rippleClassname}`} onComplete={this.handleClick}>
           {this.constructor.renderIcon()}

--- a/frontend/components/ShareButtonForTabletExtension/index.jsx
+++ b/frontend/components/ShareButtonForTabletExtension/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import I18n from '@shopgate/pwa-common/components/I18n';
+import { i18n } from '@shopgate/engage/core';
 import ShareIconiOS from '@shopgate/pwa-ui-ios/icons/ShareIcon';
 import ShareIconGmd from '@shopgate/pwa-ui-material/icons/ShareIcon';
 import isIOSTheme from '@shopgate-ps/pwa-extension-kit/env/helpers/isIOSTheme';
@@ -22,13 +23,6 @@ class ShareButtonForTabletExtension extends Component {
     shareParams: PropTypes.shape(),
   };
 
-  /**
-   * Context types definition.
-   * @type {{i18n: shim}}
-   */
-  static contextTypes = {
-    i18n: PropTypes.func,
-  };
 
   static defaultProps = {
     'aria-hidden': null,
@@ -59,16 +53,6 @@ class ShareButtonForTabletExtension extends Component {
   }
 
   /**
-   * Returns text for aria-label.
-   * @returns {string}
-   */
-  getLabel() {
-    const { __ } = this.context.i18n();
-    const lang = 'shareButton.label';
-    return __(lang);
-  }
-
-  /**
    * Handles the share button click
    * Show's share screen for app
    * @param {Object} event The click event object
@@ -96,7 +80,7 @@ class ShareButtonForTabletExtension extends Component {
 
     return (
       <button
-        aria-label={this.getLabel()}
+        aria-label={i18n.text('pdpNativeShare.shareButton.label')}
         aria-hidden={this.props['aria-hidden']}
         className={`ui-shared__share-button-for-tablet-extension ${styles.button}`}
         onClick={this.handleClick}

--- a/frontend/components/ShareButtonForTabletExtension/style.js
+++ b/frontend/components/ShareButtonForTabletExtension/style.js
@@ -32,7 +32,7 @@ const icon = css({
   display: 'inline',
   marginBottom: -2,
   marginRight: 5,
-});
+}).toString();
 
 export default {
   button,

--- a/frontend/locale/de-DE.json
+++ b/frontend/locale/de-DE.json
@@ -1,7 +1,7 @@
 {
   "pdpNativeShare": {
     "shareButton": {
-      "label": "Artikel teilen"
+      "label": "Produkt teilen"
     }
   }
 }


### PR DESCRIPTION
# Description

This pull request fixes the a11y label for the share button on tablets.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

The https://github.com/shopgate-professional-services/ext-tablet-adjustments extension is needed for testing